### PR TITLE
Fix min/max latency summing for multithreaded runs

### DIFF
--- a/dnsperf.c
+++ b/dnsperf.c
@@ -364,8 +364,11 @@ sum_stats(const config_t *config, stats_t *total)
 
 		total->latency_sum += stats->latency_sum;
 		total->latency_sum_squares += stats->latency_sum_squares;
-		total->latency_min += stats->latency_min;
-		total->latency_max += stats->latency_max;
+		if (stats->latency_min < total->latency_min || i == 0)
+		    total->latency_min = stats->latency_min;
+		if (stats->latency_max > total->latency_max)
+		    total->latency_max = stats->latency_max;
+
 	}
 }
 


### PR DESCRIPTION
Min/max latency is broken for multithreaded multiclient runs, because the thread summaring routine simply sums the individual min/max values, instead of choosing the min/max from them.

To test, simply run a test with both `-c` and `-T` > 1. You should see that the "min" latency is greater than the average. Assuming a fairly even distribution, dividing by `min(-c, -T)` should get you more reasonable numbers, indicating the individaul min/maxes are summed.

This patch should return min/max to normal under multithreaded circumstances.